### PR TITLE
export businessObject endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skycell-ag/shared-components",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skycell-ag/shared-components",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@date-io/moment": "1.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skycell-ag/shared-components",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": false,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -54,3 +54,6 @@ export {
 export {
     initVariables,
 } from './init'
+export {
+    default as businessObjects,
+} from './services/businessObjects'


### PR DESCRIPTION
exporting businessObjects endpoint to not duplicate the same code in SkyCenter for other app specific requests