### PR TITLE
[ID-12724] add TypeScript types for Card and TemperatureChart2 components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skycell-ag/shared-components",
-  "version": "9.2.7",
+  "version": "9.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skycell-ag/shared-components",
-      "version": "9.2.7",
+      "version": "9.2.8",
       "license": "MIT",
       "dependencies": {
         "@date-io/moment": "2.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skycell-ag/shared-components",
-  "version": "9.2.7",
+  "version": "9.2.8",
   "private": false,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,6 +21,27 @@ declare module '@skycell-ag/shared-components' {
 
     const TemperatureChart: React.FC<TemperatureChartProps>
 
+    interface TemperatureChart2Props {
+        sensorData?: {
+            d?: number[],
+            t?: string,
+        }[],
+        sensorLabels: string[],
+        onError?: (error: string) => void,
+        isChartPrinting?: boolean,
+        onFullScreen?: () => void,
+        userOptions?: any,
+        temperatureChartFullscreen?: boolean,
+        setTemperatureChartFullscreen?: (value: boolean) => void,
+        customColumns?: any[],
+        customData?: any[],
+        allowFullScreen?: boolean,
+        customClassName?: string,
+        isDateRange: boolean,
+    }
+
+    const TemperatureChart2: React.FC<TemperatureChart2Props>
+
     interface RouteProps {
         destinations: [number, number][]
     }
@@ -119,4 +140,17 @@ declare module '@skycell-ag/shared-components' {
         children: JSX.Element
     }
     const I18nLocaleProvider: React.FC<I18nLocaleProviderProps>
+
+    interface CardProps {
+        children: JSX.Element,
+        title?: string,
+        icon?: string,
+        className?: string,
+        contentClass?: string,
+        titleClass?: string,
+        fullHeight?: boolean,
+        status?: string,
+    }
+
+    const Card: React.FC<CardProps>
 }


### PR DESCRIPTION
implemented TypeScript types  for Card and TemperatureChart2 component to be able use them in TypeScript files in SkyNet